### PR TITLE
Fixed Kingpaca Cryst wiki image and name

### DIFF
--- a/src/pals.json
+++ b/src/pals.json
@@ -14120,10 +14120,10 @@
     "id": 131,
     "key": "089B",
     "image": "/public/images/paldeck/089B.png",
-    "name": "Ice Kingpaca",
-    "wiki": "https://palworld.fandom.com/wiki/Ice_Kingpaca",
+    "name": "Kingpaca Cryst",
+    "wiki": "https://palworld.fandom.com/wiki/Kingpaca_Cryst",
     "types": ["ice"],
-    "imageWiki": "https://static.wikia.nocookie.net/palworld/images/5/5a/Ice_Kingpaca_menu.png",
+    "imageWiki": "https://static.wikia.nocookie.net/palworld/images/4/49/Kingpaca_Cryst_menu.png",
     "suitability": [
       {
         "type": "gathering",


### PR DESCRIPTION
The name for `Ice Kingpaca` was changed to `Kingpaca Cryst` to match the name in-game. This reflects that change. 