### PR TITLE
feat: added breed_power

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,8 @@ This is the first Palworld API, it's a simple API to get all Palworld Paldex dat
       "genus": "monster",
       "rarity": 8,
       "price": 10240,
-      "size": "xl"
+      "size": "xl",
+      "breed_power": 280
     }
   ],
   "page": 1,

--- a/README.md
+++ b/README.md
@@ -149,7 +149,12 @@ This is the first Palworld API, it's a simple API to get all Palworld Paldex dat
       "rarity": 8,
       "price": 10240,
       "size": "xl",
-      "breed_power": 280
+      "breeding": {
+        "rank": 280,
+        "order": 54,
+        "child_eligble": true,
+        "male_probability": 50.0
+      }
     }
   ],
   "page": 1,

--- a/src/common/interfaces/breed.interface.ts
+++ b/src/common/interfaces/breed.interface.ts
@@ -1,0 +1,23 @@
+export interface IBreedMeta {
+  /**
+   * Used in calculating the children from two parents.
+   * The child's rank is calculated by floor((parent_a_rank + parent_b_rank + 1) / 2)
+   */
+  rank: number;
+
+  /**
+   * Defines the check order for resolving ties in breeding outcomes.
+   * Lower values are prioritized when two potential offspring are equidistant from the parent's average rank.
+   */
+  order: number;
+
+  /**
+   * If false, the pal cannot be the result of parents other than the child if no special cases apply.
+   */
+  child_eligble: boolean;
+
+  /**
+   * The probability from 0.0 to 1.0 that the Pal will be male.
+   */
+  male_probability: number;
+}

--- a/src/common/interfaces/pal.interface.ts
+++ b/src/common/interfaces/pal.interface.ts
@@ -1,6 +1,7 @@
 import type { ISuitability } from ".";
 import type { TypesEnum } from "../enums";
 import type { IAura } from "./aura.interface";
+import type { IBreedMeta } from "./breed.interface";
 import type { ISkill } from "./skill.interface";
 import type { IStats } from "./stats.interface";
 
@@ -23,5 +24,5 @@ export interface IPal {
   rarity: number;
   price: number;
   size: "l" | "xl" | "xs" | "m" | "s";
-  breed_power: number;
+  breed: IBreedMeta;
 }

--- a/src/common/interfaces/pal.interface.ts
+++ b/src/common/interfaces/pal.interface.ts
@@ -23,4 +23,5 @@ export interface IPal {
   rarity: number;
   price: number;
   size: "l" | "xl" | "xs" | "m" | "s";
+  breed_power: number;
 }

--- a/src/pals.json
+++ b/src/pals.json
@@ -113,7 +113,8 @@
     "maps": {
       "day": "/public/images/maps/001-day.png",
       "night": "/public/images/maps/001-night.png"
-    }
+    },
+    "breed_power": 1470
   },
   {
     "id": 2,
@@ -234,7 +235,8 @@
     "maps": {
       "day": "/public/images/maps/002-day.png",
       "night": "/public/images/maps/002-night.png"
-    }
+    },
+    "breed_power": 1460
   },
   {
     "id": 3,
@@ -345,7 +347,8 @@
     "maps": {
       "day": "/public/images/maps/003-day.png",
       "night": "/public/images/maps/003-night.png"
-    }
+    },
+    "breed_power": 1500
   },
   {
     "id": 4,
@@ -471,7 +474,8 @@
     "maps": {
       "day": "/public/images/maps/004-day.png",
       "night": "/public/images/maps/004-night.png"
-    }
+    },
+    "breed_power": 1430
   },
   {
     "id": 5,
@@ -577,7 +581,8 @@
     "maps": {
       "day": "/public/images/maps/005-day.png",
       "night": "/public/images/maps/005-night.png"
-    }
+    },
+    "breed_power": 1400
   },
   {
     "id": 6,
@@ -693,7 +698,8 @@
     "maps": {
       "day": "/public/images/maps/006-day.png",
       "night": "/public/images/maps/006-night.png"
-    }
+    },
+    "breed_power": 1330
   },
   {
     "id": 7,
@@ -809,7 +815,8 @@
     "maps": {
       "day": "/public/images/maps/007-day.png",
       "night": "/public/images/maps/007-night.png"
-    }
+    },
+    "breed_power": 1410
   },
   {
     "id": 8,
@@ -935,7 +942,8 @@
     "maps": {
       "day": "/public/images/maps/008-day.png",
       "night": "/public/images/maps/008-night.png"
-    }
+    },
+    "breed_power": 1250
   },
   {
     "id": 9,
@@ -1041,7 +1049,8 @@
     "maps": {
       "day": "/public/images/maps/009-day.png",
       "night": "/public/images/maps/009-night.png"
-    }
+    },
+    "breed_power": 1155
   },
   {
     "id": 10,
@@ -1162,7 +1171,8 @@
     "maps": {
       "day": "/public/images/maps/010-day.png",
       "night": "/public/images/maps/010-night.png"
-    }
+    },
+    "breed_power": 1350
   },
   {
     "id": 11,
@@ -1288,7 +1298,8 @@
     "maps": {
       "day": "/public/images/maps/011-day.png",
       "night": "/public/images/maps/011-night.png"
-    }
+    },
+    "breed_power": 520
   },
   {
     "id": 12,
@@ -1394,7 +1405,8 @@
     "maps": {
       "day": "/public/images/maps/012-day.png",
       "night": "/public/images/maps/012-night.png"
-    }
+    },
+    "breed_power": 1370
   },
   {
     "id": 13,
@@ -1500,7 +1512,8 @@
     "maps": {
       "day": "/public/images/maps/013-day.png",
       "night": "/public/images/maps/013-night.png"
-    }
+    },
+    "breed_power": 1240
   },
   {
     "id": 14,
@@ -1611,7 +1624,8 @@
     "maps": {
       "day": "/public/images/maps/014-day.png",
       "night": "/public/images/maps/014-night.png"
-    }
+    },
+    "breed_power": 1450
   },
   {
     "id": 15,
@@ -1716,7 +1730,8 @@
     "size": "xs",
     "maps": {
       "night": "/public/images/maps/015-night.png"
-    }
+    },
+    "breed_power": 1390
   },
   {
     "id": 16,
@@ -1822,7 +1837,8 @@
     "maps": {
       "day": "/public/images/maps/016-day.png",
       "night": "/public/images/maps/016-night.png"
-    }
+    },
+    "breed_power": 1490
   },
   {
     "id": 17,
@@ -1937,7 +1953,8 @@
     "size": "xs",
     "maps": {
       "night": "/public/images/maps/017-night.png"
-    }
+    },
+    "breed_power": 1380
   },
   {
     "id": 18,
@@ -2047,7 +2064,8 @@
     "size": "xs",
     "maps": {
       "day": "/public/images/maps/018-day.png"
-    }
+    },
+    "breed_power": 1455
   },
   {
     "id": 19,
@@ -2162,7 +2180,8 @@
     "size": "xs",
     "maps": {
       "night": "/public/images/maps/019-night.png"
-    }
+    },
+    "breed_power": 1230
   },
   {
     "id": 20,
@@ -2268,7 +2287,8 @@
     "maps": {
       "day": "/public/images/maps/020-day.png",
       "night": "/public/images/maps/020-night.png"
-    }
+    },
+    "breed_power": 1130
   },
   {
     "id": 21,
@@ -2373,7 +2393,8 @@
     "size": "xs",
     "maps": {
       "night": "/public/images/maps/021-night.png"
-    }
+    },
+    "breed_power": 1180
   },
   {
     "id": 22,
@@ -2489,7 +2510,8 @@
     "maps": {
       "day": "/public/images/maps/022-day.png",
       "night": "/public/images/maps/022-night.png"
-    }
+    },
+    "breed_power": 1220
   },
   {
     "id": 23,
@@ -2597,7 +2619,8 @@
     "rarity": 1,
     "price": 1200,
     "size": "xs",
-    "maps": {}
+    "maps": {},
+    "breed_power": 1290
   },
   {
     "id": 24,
@@ -2700,7 +2723,8 @@
     "rarity": 1,
     "price": 1000,
     "size": "xs",
-    "maps": {}
+    "maps": {},
+    "breed_power": 1480
   },
   {
     "id": 25,
@@ -2811,7 +2835,8 @@
     "maps": {
       "day": "/public/images/maps/025-day.png",
       "night": "/public/images/maps/025-night.png"
-    }
+    },
+    "breed_power": 870
   },
   {
     "id": 26,
@@ -2917,7 +2942,8 @@
     "maps": {
       "day": "/public/images/maps/026-day.png",
       "night": "/public/images/maps/026-night.png"
-    }
+    },
+    "breed_power": 1060
   },
   {
     "id": 27,
@@ -3023,7 +3049,8 @@
     "maps": {
       "day": "/public/images/maps/027-day.png",
       "night": "/public/images/maps/027-night.png"
-    }
+    },
+    "breed_power": 1340
   },
   {
     "id": 28,
@@ -3149,7 +3176,8 @@
     "maps": {
       "day": "/public/images/maps/028-day.png",
       "night": "/public/images/maps/028-night.png"
-    }
+    },
+    "breed_power": 1280
   },
   {
     "id": 29,
@@ -3255,7 +3283,8 @@
     "maps": {
       "day": "/public/images/maps/029-day.png",
       "night": "/public/images/maps/029-night.png"
-    }
+    },
+    "breed_power": 910
   },
   {
     "id": 30,
@@ -3381,7 +3410,8 @@
     "maps": {
       "day": "/public/images/maps/030-day.png",
       "night": "/public/images/maps/030-night.png"
-    }
+    },
+    "breed_power": 1320
   },
   {
     "id": 31,
@@ -3497,7 +3527,8 @@
     "maps": {
       "day": "/public/images/maps/031-day.png",
       "night": "/public/images/maps/031-night.png"
-    }
+    },
+    "breed_power": 1090
   },
   {
     "id": 32,
@@ -3613,7 +3644,8 @@
     "maps": {
       "day": "/public/images/maps/032-day.png",
       "night": "/public/images/maps/032-night.png"
-    }
+    },
+    "breed_power": 1420
   },
   {
     "id": 33,
@@ -3734,7 +3766,8 @@
     "maps": {
       "day": "/public/images/maps/033-day.png",
       "night": "/public/images/maps/033-night.png"
-    }
+    },
+    "breed_power": 430
   },
   {
     "id": 34,
@@ -3840,7 +3873,8 @@
     "maps": {
       "day": "/public/images/maps/034-day.png",
       "night": "/public/images/maps/034-night.png"
-    }
+    },
+    "breed_power": 1190
   },
   {
     "id": 35,
@@ -3951,7 +3985,8 @@
     "maps": {
       "day": "/public/images/maps/035-day.png",
       "night": "/public/images/maps/035-night.png"
-    }
+    },
+    "breed_power": 930
   },
   {
     "id": 36,
@@ -4057,7 +4092,8 @@
     "maps": {
       "day": "/public/images/maps/036-day.png",
       "night": "/public/images/maps/036-night.png"
-    }
+    },
+    "breed_power": 890
   },
   {
     "id": 37,
@@ -4163,7 +4199,8 @@
     "maps": {
       "day": "/public/images/maps/037-day.png",
       "night": "/public/images/maps/037-night.png"
-    }
+    },
+    "breed_power": 920
   },
   {
     "id": 38,
@@ -4269,7 +4306,8 @@
     "maps": {
       "day": "/public/images/maps/038-day.png",
       "night": "/public/images/maps/038-night.png"
-    }
+    },
+    "breed_power": 420
   },
   {
     "id": 39,
@@ -4385,7 +4423,8 @@
     "maps": {
       "day": "/public/images/maps/039-day.png",
       "night": "/public/images/maps/039-night.png"
-    }
+    },
+    "breed_power": 1310
   },
   {
     "id": 40,
@@ -4506,7 +4545,8 @@
     "maps": {
       "day": "/public/images/maps/040-day.png",
       "night": "/public/images/maps/040-night.png"
-    }
+    },
+    "breed_power": 590
   },
   {
     "id": 41,
@@ -4617,7 +4657,8 @@
     "maps": {
       "day": "/public/images/maps/041-day.png",
       "night": "/public/images/maps/041-night.png"
-    }
+    },
+    "breed_power": 490
   },
   {
     "id": 42,
@@ -4728,7 +4769,8 @@
     "maps": {
       "day": "/public/images/maps/042-day.png",
       "night": "/public/images/maps/042-night.png"
-    }
+    },
+    "breed_power": 790
   },
   {
     "id": 43,
@@ -4787,7 +4829,8 @@
     "maps": {
       "day": "/public/images/maps/043-day.png",
       "night": "/public/images/maps/043-night.png"
-    }
+    },
+    "breed_power": 895
   },
   {
     "id": 44,
@@ -4892,7 +4935,8 @@
     "size": "m",
     "maps": {
       "night": "/public/images/maps/044-night.png"
-    }
+    },
+    "breed_power": 1080
   },
   {
     "id": 45,
@@ -5008,7 +5052,8 @@
     "maps": {
       "day": "/public/images/maps/045-day.png",
       "night": "/public/images/maps/045-night.png"
-    }
+    },
+    "breed_power": 1120
   },
   {
     "id": 46,
@@ -5113,7 +5158,8 @@
     "size": "m",
     "maps": {
       "night": "/public/images/maps/046-night.png"
-    }
+    },
+    "breed_power": 950
   },
   {
     "id": 47,
@@ -5219,7 +5265,8 @@
     "maps": {
       "day": "/public/images/maps/047-day.png",
       "night": "/public/images/maps/047-night.png"
-    }
+    },
+    "breed_power": 1030
   },
   {
     "id": 48,
@@ -5350,7 +5397,8 @@
     "maps": {
       "day": "/public/images/maps/048-day.png",
       "night": "/public/images/maps/048-night.png"
-    }
+    },
+    "breed_power": 1020
   },
   {
     "id": 49,
@@ -5466,7 +5514,8 @@
     "maps": {
       "day": "/public/images/maps/049-day.png",
       "night": "/public/images/maps/049-night.png"
-    }
+    },
+    "breed_power": 1040
   },
   {
     "id": 50,
@@ -5602,7 +5651,8 @@
     "maps": {
       "day": "/public/images/maps/050-day.png",
       "night": "/public/images/maps/050-night.png"
-    }
+    },
+    "breed_power": 1070
   },
   {
     "id": 51,
@@ -5728,7 +5778,8 @@
     "maps": {
       "day": "/public/images/maps/051-day.png",
       "night": "/public/images/maps/051-night.png"
-    }
+    },
+    "breed_power": 330
   },
   {
     "id": 52,
@@ -5834,7 +5885,8 @@
     "maps": {
       "day": "/public/images/maps/052-day.png",
       "night": "/public/images/maps/052-night.png"
-    }
+    },
+    "breed_power": 510
   },
   {
     "id": 53,
@@ -5945,7 +5997,8 @@
     "maps": {
       "day": "/public/images/maps/053-day.png",
       "night": "/public/images/maps/053-night.png"
-    }
+    },
+    "breed_power": 1300
   },
   {
     "id": 54,
@@ -6056,7 +6109,8 @@
     "maps": {
       "day": "/public/images/maps/054-day.png",
       "night": "/public/images/maps/054-night.png"
-    }
+    },
+    "breed_power": 410
   },
   {
     "id": 55,
@@ -6167,7 +6221,8 @@
     "maps": {
       "day": "/public/images/maps/055-day.png",
       "night": "/public/images/maps/055-night.png"
-    }
+    },
+    "breed_power": 800
   },
   {
     "id": 56,
@@ -6278,7 +6333,8 @@
     "maps": {
       "day": "/public/images/maps/056-day.png",
       "night": "/public/images/maps/056-night.png"
-    }
+    },
+    "breed_power": 680
   },
   {
     "id": 57,
@@ -6384,7 +6440,8 @@
     "maps": {
       "day": "/public/images/maps/057-day.png",
       "night": "/public/images/maps/057-night.png"
-    }
+    },
+    "breed_power": 760
   },
   {
     "id": 58,
@@ -6495,7 +6552,8 @@
     "maps": {
       "day": "/public/images/maps/058-day.png",
       "night": "/public/images/maps/058-night.png"
-    }
+    },
+    "breed_power": 360
   },
   {
     "id": 59,
@@ -6606,7 +6664,8 @@
     "maps": {
       "day": "/public/images/maps/059-day.png",
       "night": "/public/images/maps/059-night.png"
-    }
+    },
+    "breed_power": 880
   },
   {
     "id": 60,
@@ -6712,7 +6771,8 @@
     "maps": {
       "day": "/public/images/maps/060-day.png",
       "night": "/public/images/maps/060-night.png"
-    }
+    },
+    "breed_power": 740
   },
   {
     "id": 61,
@@ -6817,7 +6877,8 @@
     "size": "m",
     "maps": {
       "night": "/public/images/maps/061-night.png"
-    }
+    },
+    "breed_power": 830
   },
   {
     "id": 62,
@@ -6933,7 +6994,8 @@
     "maps": {
       "day": "/public/images/maps/062-day.png",
       "night": "/public/images/maps/062-night.png"
-    }
+    },
+    "breed_power": 1210
   },
   {
     "id": 63,
@@ -7046,7 +7108,8 @@
     "rarity": 6,
     "price": 1760,
     "size": "m",
-    "maps": {}
+    "maps": {},
+    "breed_power": 1110
   },
   {
     "id": 64,
@@ -7157,7 +7220,8 @@
     "maps": {
       "day": "/public/images/maps/064-day.png",
       "night": "/public/images/maps/064-night.png"
-    }
+    },
+    "breed_power": 820
   },
   {
     "id": 65,
@@ -7263,7 +7327,8 @@
     "maps": {
       "day": "/public/images/maps/065-day.png",
       "night": "/public/images/maps/065-night.png"
-    }
+    },
+    "breed_power": 560
   },
   {
     "id": 66,
@@ -7373,7 +7438,8 @@
     "size": "m",
     "maps": {
       "night": "/public/images/maps/066-night.png"
-    }
+    },
+    "breed_power": 1150
   },
   {
     "id": 67,
@@ -7479,7 +7545,8 @@
     "maps": {
       "day": "/public/images/maps/067-day.png",
       "night": "/public/images/maps/067-night.png"
-    }
+    },
+    "breed_power": 850
   },
   {
     "id": 68,
@@ -7594,7 +7661,8 @@
     "size": "m",
     "maps": {
       "night": "/public/images/maps/068-night.png"
-    }
+    },
+    "breed_power": 750
   },
   {
     "id": 69,
@@ -7714,7 +7782,8 @@
     "size": "l",
     "maps": {
       "night": "/public/images/maps/069-night.png"
-    }
+    },
+    "breed_power": 940
   },
   {
     "id": 70,
@@ -7835,7 +7904,8 @@
     "maps": {
       "day": "/public/images/maps/070-day.png",
       "night": "/public/images/maps/070-night.png"
-    }
+    },
+    "breed_power": 1405
   },
   {
     "id": 71,
@@ -7946,7 +8016,8 @@
     "maps": {
       "day": "/public/images/maps/071-day.png",
       "night": "/public/images/maps/071-night.png"
-    }
+    },
+    "breed_power": 660
   },
   {
     "id": 72,
@@ -8072,7 +8143,8 @@
     "maps": {
       "day": "/public/images/maps/072-day.png",
       "night": "/public/images/maps/072-night.png"
-    }
+    },
+    "breed_power": 640
   },
   {
     "id": 73,
@@ -8188,7 +8260,8 @@
     "maps": {
       "day": "/public/images/maps/073-day.png",
       "night": "/public/images/maps/073-night.png"
-    }
+    },
+    "breed_power": 220
   },
   {
     "id": 74,
@@ -8299,7 +8372,8 @@
     "maps": {
       "day": "/public/images/maps/074-day.png",
       "night": "/public/images/maps/074-night.png"
-    }
+    },
+    "breed_power": 380
   },
   {
     "id": 75,
@@ -8414,7 +8488,8 @@
     "size": "m",
     "maps": {
       "night": "/public/images/maps/075-night.png"
-    }
+    },
+    "breed_power": 700
   },
   {
     "id": 76,
@@ -8530,7 +8605,8 @@
     "maps": {
       "day": "/public/images/maps/076-day.png",
       "night": "/public/images/maps/076-night.png"
-    }
+    },
+    "breed_power": 1160
   },
   {
     "id": 77,
@@ -8656,7 +8732,8 @@
     "maps": {
       "day": "/public/images/maps/077-day.png",
       "night": "/public/images/maps/077-night.png"
-    }
+    },
+    "breed_power": 990
   },
   {
     "id": 78,
@@ -8782,7 +8859,8 @@
     "maps": {
       "day": "/public/images/maps/078-day.png",
       "night": "/public/images/maps/078-night.png"
-    }
+    },
+    "breed_power": 1050
   },
   {
     "id": 79,
@@ -8898,7 +8976,8 @@
     "maps": {
       "day": "/public/images/maps/079-day.png",
       "night": "/public/images/maps/079-night.png"
-    }
+    },
+    "breed_power": 450
   },
   {
     "id": 80,
@@ -9004,7 +9083,8 @@
     "maps": {
       "day": "/public/images/maps/080-day.png",
       "night": "/public/images/maps/080-night.png"
-    }
+    },
+    "breed_power": 540
   },
   {
     "id": 81,
@@ -9110,7 +9190,8 @@
     "maps": {
       "day": "/public/images/maps/081-day.png",
       "night": "/public/images/maps/081-night.png"
-    }
+    },
+    "breed_power": 1260
   },
   {
     "id": 82,
@@ -9216,7 +9297,8 @@
     "maps": {
       "day": "/public/images/maps/082-day.png",
       "night": "/public/images/maps/082-night.png"
-    }
+    },
+    "breed_power": 500
   },
   {
     "id": 83,
@@ -9332,7 +9414,8 @@
     "maps": {
       "day": "/public/images/maps/083-day.png",
       "night": "/public/images/maps/083-night.png"
-    }
+    },
+    "breed_power": 130
   },
   {
     "id": 84,
@@ -9360,7 +9443,7 @@
       "description": "Can be ridden. While fighting together, Grass Pals drop more items when defeated.",
       "tech": null
     },
-    "description": "While it prefers raw meat, it always ends up eating well-done meat. This is due to its blistering claws, which it uses as its weapon—it simply doesn't realize its prey gets burned to a crisp.",
+    "description": "While it prefers raw meat, it always ends up eating well-done meat. This is due to its blistering claws, which it uses as its weapon\u00e2\u20ac\u201dit simply doesn't realize its prey gets burned to a crisp.",
     "skills": [
       {
         "level": 1,
@@ -9443,7 +9526,8 @@
     "maps": {
       "day": "/public/images/maps/084-day.png",
       "night": "/public/images/maps/084-night.png"
-    }
+    },
+    "breed_power": 710
   },
   {
     "id": 85,
@@ -9471,7 +9555,7 @@
       "description": "Can be ridden. Can rapidly fire a missile launcher while mounted.",
       "tech": null
     },
-    "description": "Contrary to its blasé appearance, it's quite ferocious.\nIt perceives everything in its sight as prey and will stop at nothing to devour it.",
+    "description": "Contrary to its blas\u00c3\u00a9 appearance, it's quite ferocious.\nIt perceives everything in its sight as prey and will stop at nothing to devour it.",
     "skills": [
       {
         "level": 1,
@@ -9554,7 +9638,8 @@
     "maps": {
       "day": "/public/images/maps/085-day.png",
       "night": "/public/images/maps/085-night.png"
-    }
+    },
+    "breed_power": 280
   },
   {
     "id": 86,
@@ -9660,7 +9745,8 @@
     "maps": {
       "day": "/public/images/maps/086-day.png",
       "night": "/public/images/maps/086-night.png"
-    }
+    },
+    "breed_power": 860
   },
   {
     "id": 87,
@@ -9786,7 +9872,8 @@
     "maps": {
       "day": "/public/images/maps/087-day.png",
       "night": "/public/images/maps/087-night.png"
-    }
+    },
+    "breed_power": 780
   },
   {
     "id": 88,
@@ -9897,7 +9984,8 @@
     "maps": {
       "day": "/public/images/maps/088-day.png",
       "night": "/public/images/maps/088-night.png"
-    }
+    },
+    "breed_power": 320
   },
   {
     "id": 89,
@@ -10003,7 +10091,8 @@
     "maps": {
       "day": "/public/images/maps/089-day.png",
       "night": "/public/images/maps/089-night.png"
-    }
+    },
+    "breed_power": 470
   },
   {
     "id": 90,
@@ -10119,7 +10208,8 @@
     "maps": {
       "day": "/public/images/maps/090-day.png",
       "night": "/public/images/maps/090-night.png"
-    }
+    },
+    "breed_power": 300
   },
   {
     "id": 91,
@@ -10240,7 +10330,8 @@
     "maps": {
       "day": "/public/images/maps/091-day.png",
       "night": "/public/images/maps/091-night.png"
-    }
+    },
+    "breed_power": 460
   },
   {
     "id": 92,
@@ -10361,7 +10452,8 @@
     "maps": {
       "day": "/public/images/maps/092-day.png",
       "night": "/public/images/maps/092-night.png"
-    }
+    },
+    "breed_power": 340
   },
   {
     "id": 93,
@@ -10467,7 +10559,8 @@
     "maps": {
       "day": "/public/images/maps/093-day.png",
       "night": "/public/images/maps/093-night.png"
-    }
+    },
+    "breed_power": 980
   },
   {
     "id": 94,
@@ -10570,7 +10663,8 @@
     "rarity": 6,
     "price": 2100,
     "size": "m",
-    "maps": {}
+    "maps": {},
+    "breed_power": 1010
   },
   {
     "id": 95,
@@ -10691,7 +10785,8 @@
     "maps": {
       "day": "/public/images/maps/095-day.png",
       "night": "/public/images/maps/095-night.png"
-    }
+    },
+    "breed_power": 350
   },
   {
     "id": 96,
@@ -10802,7 +10897,8 @@
     "maps": {
       "day": "/public/images/maps/096-day.png",
       "night": "/public/images/maps/096-night.png"
-    }
+    },
+    "breed_power": 10
   },
   {
     "id": 97,
@@ -10907,7 +11003,8 @@
     "size": "l",
     "maps": {
       "night": "/public/images/maps/097-night.png"
-    }
+    },
+    "breed_power": 190
   },
   {
     "id": 98,
@@ -11018,7 +11115,8 @@
     "maps": {
       "day": "/public/images/maps/098-day.png",
       "night": "/public/images/maps/098-night.png"
-    }
+    },
+    "breed_power": 150
   },
   {
     "id": 99,
@@ -11129,7 +11227,8 @@
     "maps": {
       "day": "/public/images/maps/099-day.png",
       "night": "/public/images/maps/099-night.png"
-    }
+    },
+    "breed_power": 260
   },
   {
     "id": 100,
@@ -11242,7 +11341,8 @@
     "rarity": 10,
     "price": 4960,
     "size": "m",
-    "maps": {}
+    "maps": {},
+    "breed_power": 570
   },
   {
     "id": 101,
@@ -11348,7 +11448,8 @@
     "maps": {
       "day": "/public/images/maps/101-day.png",
       "night": "/public/images/maps/101-night.png"
-    }
+    },
+    "breed_power": 310
   },
   {
     "id": 102,
@@ -11454,7 +11555,8 @@
     "maps": {
       "day": "/public/images/maps/102-day.png",
       "night": "/public/images/maps/102-night.png"
-    }
+    },
+    "breed_power": 50
   },
   {
     "id": 103,
@@ -11575,7 +11677,8 @@
     "maps": {
       "day": "/public/images/maps/103-day.png",
       "night": "/public/images/maps/103-night.png"
-    }
+    },
+    "breed_power": 200
   },
   {
     "id": 104,
@@ -11700,7 +11803,8 @@
     "maps": {
       "day": "/public/images/maps/104-day.png",
       "night": "/public/images/maps/104-night.png"
-    }
+    },
+    "breed_power": 250
   },
   {
     "id": 105,
@@ -11811,7 +11915,8 @@
     "maps": {
       "day": "/public/images/maps/105-day.png",
       "night": "/public/images/maps/105-night.png"
-    }
+    },
+    "breed_power": 370
   },
   {
     "id": 106,
@@ -11927,7 +12032,8 @@
     "maps": {
       "day": "/public/images/maps/106-day.png",
       "night": "/public/images/maps/106-night.png"
-    }
+    },
+    "breed_power": 140
   },
   {
     "id": 107,
@@ -12033,7 +12139,8 @@
     "maps": {
       "day": "/public/images/maps/107-day.png",
       "night": "/public/images/maps/107-night.png"
-    }
+    },
+    "breed_power": 60
   },
   {
     "id": 108,
@@ -12144,7 +12251,8 @@
     "maps": {
       "day": "/public/images/maps/108-day.png",
       "night": "/public/images/maps/108-night.png"
-    }
+    },
+    "breed_power": 80
   },
   {
     "id": 109,
@@ -12255,7 +12363,8 @@
     "maps": {
       "day": "/public/images/maps/109-day.png",
       "night": "/public/images/maps/109-night.png"
-    }
+    },
+    "breed_power": 70
   },
   {
     "id": 110,
@@ -12361,7 +12470,8 @@
     "maps": {
       "day": "/public/images/maps/110-day.png",
       "night": "/public/images/maps/110-night.png"
-    }
+    },
+    "breed_power": 120
   },
   {
     "id": 111,
@@ -12467,7 +12577,8 @@
     "maps": {
       "day": "/public/images/maps/111-day.png",
       "night": "/public/images/maps/111-night.png"
-    }
+    },
+    "breed_power": 90
   },
   {
     "id": 112,
@@ -12570,7 +12681,8 @@
     "rarity": 2,
     "price": 1070,
     "size": "xs",
-    "maps": {}
+    "maps": {},
+    "breed_power": 1360
   },
   {
     "id": 113,
@@ -12681,7 +12793,8 @@
     "maps": {
       "day": "/public/images/maps/024B-day.png",
       "night": "/public/images/maps/024B-night.png"
-    }
+    },
+    "breed_power": 1440
   },
   {
     "id": 114,
@@ -12796,7 +12909,8 @@
     "size": "s",
     "maps": {
       "day": "/public/images/maps/031B-day.png"
-    }
+    },
+    "breed_power": 1100
   },
   {
     "id": 115,
@@ -12916,7 +13030,8 @@
     "size": "xs",
     "maps": {
       "night": "/public/images/maps/032B-night.png"
-    }
+    },
+    "breed_power": 1422
   },
   {
     "id": 116,
@@ -13037,7 +13152,8 @@
     "maps": {
       "day": "/public/images/maps/033B-day.png",
       "night": "/public/images/maps/033B-night.png"
-    }
+    },
+    "breed_power": 390
   },
   {
     "id": 117,
@@ -13143,7 +13259,8 @@
     "maps": {
       "day": "/public/images/maps/037B-day.png",
       "night": "/public/images/maps/037B-night.png"
-    }
+    },
+    "breed_power": 900
   },
   {
     "id": 118,
@@ -13259,7 +13376,8 @@
     "maps": {
       "day": "/public/images/maps/040B-day.png",
       "night": "/public/images/maps/040B-night.png"
-    }
+    },
+    "breed_power": 580
   },
   {
     "id": 119,
@@ -13380,7 +13498,8 @@
     "maps": {
       "day": "/public/images/maps/045B-day.png",
       "night": "/public/images/maps/045B-night.png"
-    }
+    },
+    "breed_power": 1140
   },
   {
     "id": 120,
@@ -13506,7 +13625,8 @@
     "maps": {
       "day": "/public/images/maps/048B-day.png",
       "night": "/public/images/maps/048B-night.png"
-    }
+    },
+    "breed_power": 1000
   },
   {
     "id": 121,
@@ -13616,7 +13736,8 @@
     "size": "l",
     "maps": {
       "night": "/public/images/maps/058B-night.png"
-    }
+    },
+    "breed_power": 240
   },
   {
     "id": 122,
@@ -13727,7 +13848,8 @@
     "maps": {
       "day": "/public/images/maps/064B-day.png",
       "night": "/public/images/maps/064B-night.png"
-    }
+    },
+    "breed_power": 810
   },
   {
     "id": 123,
@@ -13833,7 +13955,8 @@
     "maps": {
       "day": "/public/images/maps/065B-day.png",
       "night": "/public/images/maps/065B-night.png"
-    }
+    },
+    "breed_power": 550
   },
   {
     "id": 124,
@@ -13943,7 +14066,8 @@
     "size": "l",
     "maps": {
       "night": "/public/images/maps/071B-night.png"
-    }
+    },
+    "breed_power": 620
   },
   {
     "id": 125,
@@ -14051,7 +14175,8 @@
     "rarity": 8,
     "price": 5320,
     "size": "l",
-    "maps": {}
+    "maps": {},
+    "breed_power": 530
   },
   {
     "id": 126,
@@ -14157,7 +14282,8 @@
     "maps": {
       "day": "/public/images/maps/081B-day.png",
       "night": "/public/images/maps/081B-night.png"
-    }
+    },
+    "breed_power": 1270
   },
   {
     "id": 127,
@@ -14185,7 +14311,7 @@
       "description": "Can be ridden. While fighting together, Neutral Pals drop more items when defeated.",
       "tech": null
     },
-    "description": "While it prefers raw meat, it always ends up eating tainted meat. This is due to its dark claws, which it uses as its weapon—it simply doesn't realize its prey got cursed.",
+    "description": "While it prefers raw meat, it always ends up eating tainted meat. This is due to its dark claws, which it uses as its weapon\u00e2\u20ac\u201dit simply doesn't realize its prey got cursed.",
     "skills": [
       {
         "level": 1,
@@ -14267,7 +14393,8 @@
     "size": "l",
     "maps": {
       "night": "/public/images/maps/084B-night.png"
-    }
+    },
+    "breed_power": 670
   },
   {
     "id": 128,
@@ -14375,7 +14502,8 @@
     "rarity": 9,
     "price": 10380,
     "size": "xl",
-    "maps": {}
+    "maps": {},
+    "breed_power": 270
   },
   {
     "id": 129,
@@ -14481,7 +14609,8 @@
     "maps": {
       "day": "/public/images/maps/086B-day.png",
       "night": "/public/images/maps/086B-night.png"
-    }
+    },
+    "breed_power": 840
   },
   {
     "id": 130,
@@ -14589,7 +14718,8 @@
     "rarity": 7,
     "price": 7380,
     "size": "l",
-    "maps": {}
+    "maps": {},
+    "breed_power": 230
   },
   {
     "id": 131,
@@ -14700,7 +14830,8 @@
     "maps": {
       "day": "/public/images/maps/089B-day.png",
       "night": "/public/images/maps/089B-night.png"
-    }
+    },
+    "breed_power": 440
   },
   {
     "id": 132,
@@ -14816,7 +14947,8 @@
     "maps": {
       "day": "/public/images/maps/090B-day.png",
       "night": "/public/images/maps/090B-night.png"
-    }
+    },
+    "breed_power": 290
   },
   {
     "id": 133,
@@ -14937,7 +15069,8 @@
     "maps": {
       "day": "/public/images/maps/091B-day.png",
       "night": "/public/images/maps/091B-night.png"
-    }
+    },
+    "breed_power": 480
   },
   {
     "id": 134,
@@ -15043,7 +15176,8 @@
     "maps": {
       "day": "/public/images/maps/101B-day.png",
       "night": "/public/images/maps/101B-night.png"
-    }
+    },
+    "breed_power": 315
   },
   {
     "id": 135,
@@ -15146,7 +15280,8 @@
     "rarity": 9,
     "price": 10110,
     "size": "xl",
-    "maps": {}
+    "maps": {},
+    "breed_power": 30
   },
   {
     "id": 136,
@@ -15266,7 +15401,8 @@
     "maps": {
       "day": "/public/images/maps/104B-day.png",
       "night": "/public/images/maps/104B-night.png"
-    }
+    },
+    "breed_power": 210
   },
   {
     "id": 137,
@@ -15369,6 +15505,7 @@
     "rarity": 20,
     "price": 8560,
     "size": "l",
-    "maps": {}
+    "maps": {},
+    "breed_power": 100
   }
 ]

--- a/src/pals.json
+++ b/src/pals.json
@@ -114,7 +114,12 @@
       "day": "/public/images/maps/001-day.png",
       "night": "/public/images/maps/001-night.png"
     },
-    "breed_power": 1470
+    "breeding": {
+      "rank": 1470,
+      "order": 27,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 2,
@@ -236,7 +241,12 @@
       "day": "/public/images/maps/002-day.png",
       "night": "/public/images/maps/002-night.png"
     },
-    "breed_power": 1460
+    "breeding": {
+      "rank": 1460,
+      "order": 46,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 3,
@@ -348,7 +358,12 @@
       "day": "/public/images/maps/003-day.png",
       "night": "/public/images/maps/003-night.png"
     },
-    "breed_power": 1500
+    "breeding": {
+      "rank": 1500,
+      "order": 62,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 4,
@@ -475,7 +490,12 @@
       "day": "/public/images/maps/004-day.png",
       "night": "/public/images/maps/004-night.png"
     },
-    "breed_power": 1430
+    "breeding": {
+      "rank": 1430,
+      "order": 7,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 5,
@@ -582,7 +602,12 @@
       "day": "/public/images/maps/005-day.png",
       "night": "/public/images/maps/005-night.png"
     },
-    "breed_power": 1400
+    "breeding": {
+      "rank": 1400,
+      "order": 20,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 6,
@@ -699,7 +724,12 @@
       "day": "/public/images/maps/006-day.png",
       "night": "/public/images/maps/006-night.png"
     },
-    "breed_power": 1330
+    "breeding": {
+      "rank": 1330,
+      "order": 59,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 7,
@@ -816,7 +846,12 @@
       "day": "/public/images/maps/007-day.png",
       "night": "/public/images/maps/007-night.png"
     },
-    "breed_power": 1410
+    "breeding": {
+      "rank": 1410,
+      "order": 65,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 8,
@@ -943,7 +978,12 @@
       "day": "/public/images/maps/008-day.png",
       "night": "/public/images/maps/008-night.png"
     },
-    "breed_power": 1250
+    "breeding": {
+      "rank": 1250,
+      "order": 107,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 9,
@@ -1050,7 +1090,12 @@
       "day": "/public/images/maps/009-day.png",
       "night": "/public/images/maps/009-night.png"
     },
-    "breed_power": 1155
+    "breeding": {
+      "rank": 1155,
+      "order": 138,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 10,
@@ -1172,7 +1217,12 @@
       "day": "/public/images/maps/010-day.png",
       "night": "/public/images/maps/010-night.png"
     },
-    "breed_power": 1350
+    "breeding": {
+      "rank": 1350,
+      "order": 23,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 11,
@@ -1299,7 +1349,12 @@
       "day": "/public/images/maps/011-day.png",
       "night": "/public/images/maps/011-night.png"
     },
-    "breed_power": 520
+    "breeding": {
+      "rank": 520,
+      "order": 122,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 12,
@@ -1406,7 +1461,12 @@
       "day": "/public/images/maps/012-day.png",
       "night": "/public/images/maps/012-night.png"
     },
-    "breed_power": 1370
+    "breeding": {
+      "rank": 1370,
+      "order": 17,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 13,
@@ -1513,7 +1573,12 @@
       "day": "/public/images/maps/013-day.png",
       "night": "/public/images/maps/013-night.png"
     },
-    "breed_power": 1240
+    "breeding": {
+      "rank": 1240,
+      "order": 112,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 14,
@@ -1625,7 +1690,12 @@
       "day": "/public/images/maps/014-day.png",
       "night": "/public/images/maps/014-night.png"
     },
-    "breed_power": 1450
+    "breeding": {
+      "rank": 1450,
+      "order": 79,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 15,
@@ -1731,7 +1801,12 @@
     "maps": {
       "night": "/public/images/maps/015-night.png"
     },
-    "breed_power": 1390
+    "breeding": {
+      "rank": 1390,
+      "order": 82,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 16,
@@ -1838,7 +1913,12 @@
       "day": "/public/images/maps/016-day.png",
       "night": "/public/images/maps/016-night.png"
     },
-    "breed_power": 1490
+    "breeding": {
+      "rank": 1490,
+      "order": 14,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 17,
@@ -1954,7 +2034,12 @@
     "maps": {
       "night": "/public/images/maps/017-night.png"
     },
-    "breed_power": 1380
+    "breeding": {
+      "rank": 1380,
+      "order": 47,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 18,
@@ -2065,7 +2150,12 @@
     "maps": {
       "day": "/public/images/maps/018-day.png"
     },
-    "breed_power": 1455
+    "breeding": {
+      "rank": 1455,
+      "order": 135,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 19,
@@ -2181,7 +2271,12 @@
     "maps": {
       "night": "/public/images/maps/019-night.png"
     },
-    "breed_power": 1230
+    "breeding": {
+      "rank": 1230,
+      "order": 106,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 20,
@@ -2288,7 +2383,12 @@
       "day": "/public/images/maps/020-day.png",
       "night": "/public/images/maps/020-night.png"
     },
-    "breed_power": 1130
+    "breeding": {
+      "rank": 1130,
+      "order": 6,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 21,
@@ -2394,7 +2494,12 @@
     "maps": {
       "night": "/public/images/maps/021-night.png"
     },
-    "breed_power": 1180
+    "breeding": {
+      "rank": 1180,
+      "order": 121,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 22,
@@ -2511,7 +2616,12 @@
       "day": "/public/images/maps/022-day.png",
       "night": "/public/images/maps/022-night.png"
     },
-    "breed_power": 1220
+    "breeding": {
+      "rank": 1220,
+      "order": 101,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 23,
@@ -2620,7 +2730,12 @@
     "price": 1200,
     "size": "xs",
     "maps": {},
-    "breed_power": 1290
+    "breeding": {
+      "rank": 1290,
+      "order": 85,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 24,
@@ -2724,7 +2839,12 @@
     "price": 1000,
     "size": "xs",
     "maps": {},
-    "breed_power": 1480
+    "breeding": {
+      "rank": 1480,
+      "order": 4,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 25,
@@ -2836,7 +2956,12 @@
       "day": "/public/images/maps/025-day.png",
       "night": "/public/images/maps/025-night.png"
     },
-    "breed_power": 870
+    "breeding": {
+      "rank": 870,
+      "order": 128,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 26,
@@ -2943,7 +3068,12 @@
       "day": "/public/images/maps/026-day.png",
       "night": "/public/images/maps/026-night.png"
     },
-    "breed_power": 1060
+    "breeding": {
+      "rank": 1060,
+      "order": 15,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 27,
@@ -3050,7 +3180,12 @@
       "day": "/public/images/maps/027-day.png",
       "night": "/public/images/maps/027-night.png"
     },
-    "breed_power": 1340
+    "breeding": {
+      "rank": 1340,
+      "order": 8,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 28,
@@ -3177,7 +3312,12 @@
       "day": "/public/images/maps/028-day.png",
       "night": "/public/images/maps/028-night.png"
     },
-    "breed_power": 1280
+    "breeding": {
+      "rank": 1280,
+      "order": 91,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 29,
@@ -3284,7 +3424,12 @@
       "day": "/public/images/maps/029-day.png",
       "night": "/public/images/maps/029-night.png"
     },
-    "breed_power": 910
+    "breeding": {
+      "rank": 910,
+      "order": 86,
+      "child_eligble": true,
+      "male_probability": 20.0
+    }
   },
   {
     "id": 30,
@@ -3411,7 +3556,12 @@
       "day": "/public/images/maps/030-day.png",
       "night": "/public/images/maps/030-night.png"
     },
-    "breed_power": 1320
+    "breeding": {
+      "rank": 1320,
+      "order": 21,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 31,
@@ -3528,7 +3678,12 @@
       "day": "/public/images/maps/031-day.png",
       "night": "/public/images/maps/031-night.png"
     },
-    "breed_power": 1090
+    "breeding": {
+      "rank": 1090,
+      "order": 25,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 32,
@@ -3645,7 +3800,12 @@
       "day": "/public/images/maps/032-day.png",
       "night": "/public/images/maps/032-night.png"
     },
-    "breed_power": 1420
+    "breeding": {
+      "rank": 1420,
+      "order": 31,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 33,
@@ -3767,7 +3927,12 @@
       "day": "/public/images/maps/033-day.png",
       "night": "/public/images/maps/033-night.png"
     },
-    "breed_power": 430
+    "breeding": {
+      "rank": 430,
+      "order": 97,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 34,
@@ -3874,7 +4039,12 @@
       "day": "/public/images/maps/034-day.png",
       "night": "/public/images/maps/034-night.png"
     },
-    "breed_power": 1190
+    "breeding": {
+      "rank": 1190,
+      "order": 39,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 35,
@@ -3986,7 +4156,12 @@
       "day": "/public/images/maps/035-day.png",
       "night": "/public/images/maps/035-night.png"
     },
-    "breed_power": 930
+    "breeding": {
+      "rank": 930,
+      "order": 75,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 36,
@@ -4093,7 +4268,12 @@
       "day": "/public/images/maps/036-day.png",
       "night": "/public/images/maps/036-night.png"
     },
-    "breed_power": 890
+    "breeding": {
+      "rank": 890,
+      "order": 41,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 37,
@@ -4200,7 +4380,12 @@
       "day": "/public/images/maps/037-day.png",
       "night": "/public/images/maps/037-night.png"
     },
-    "breed_power": 920
+    "breeding": {
+      "rank": 920,
+      "order": 9,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 38,
@@ -4307,7 +4492,12 @@
       "day": "/public/images/maps/038-day.png",
       "night": "/public/images/maps/038-night.png"
     },
-    "breed_power": 420
+    "breeding": {
+      "rank": 420,
+      "order": 90,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 39,
@@ -4424,7 +4614,12 @@
       "day": "/public/images/maps/039-day.png",
       "night": "/public/images/maps/039-night.png"
     },
-    "breed_power": 1310
+    "breeding": {
+      "rank": 1310,
+      "order": 117,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 40,
@@ -4546,7 +4741,12 @@
       "day": "/public/images/maps/040-day.png",
       "night": "/public/images/maps/040-night.png"
     },
-    "breed_power": 590
+    "breeding": {
+      "rank": 590,
+      "order": 2,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 41,
@@ -4658,7 +4858,12 @@
       "day": "/public/images/maps/041-day.png",
       "night": "/public/images/maps/041-night.png"
     },
-    "breed_power": 490
+    "breeding": {
+      "rank": 490,
+      "order": 132,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 42,
@@ -4770,7 +4975,12 @@
       "day": "/public/images/maps/042-day.png",
       "night": "/public/images/maps/042-night.png"
     },
-    "breed_power": 790
+    "breeding": {
+      "rank": 790,
+      "order": 99,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 43,
@@ -4830,7 +5040,12 @@
       "day": "/public/images/maps/043-day.png",
       "night": "/public/images/maps/043-night.png"
     },
-    "breed_power": 895
+    "breeding": {
+      "rank": 895,
+      "order": 136,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 44,
@@ -4936,7 +5151,12 @@
     "maps": {
       "night": "/public/images/maps/044-night.png"
     },
-    "breed_power": 1080
+    "breeding": {
+      "rank": 1080,
+      "order": 44,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 45,
@@ -5053,7 +5273,12 @@
       "day": "/public/images/maps/045-day.png",
       "night": "/public/images/maps/045-night.png"
     },
-    "breed_power": 1120
+    "breeding": {
+      "rank": 1120,
+      "order": 57,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 46,
@@ -5159,7 +5384,12 @@
     "maps": {
       "night": "/public/images/maps/046-night.png"
     },
-    "breed_power": 950
+    "breeding": {
+      "rank": 950,
+      "order": 30,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 47,
@@ -5266,7 +5496,12 @@
       "day": "/public/images/maps/047-day.png",
       "night": "/public/images/maps/047-night.png"
     },
-    "breed_power": 1030
+    "breeding": {
+      "rank": 1030,
+      "order": 12,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 48,
@@ -5398,7 +5633,12 @@
       "day": "/public/images/maps/048-day.png",
       "night": "/public/images/maps/048-night.png"
     },
-    "breed_power": 1020
+    "breeding": {
+      "rank": 1020,
+      "order": 52,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 49,
@@ -5515,7 +5755,12 @@
       "day": "/public/images/maps/049-day.png",
       "night": "/public/images/maps/049-night.png"
     },
-    "breed_power": 1040
+    "breeding": {
+      "rank": 1040,
+      "order": 16,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 50,
@@ -5652,7 +5897,12 @@
       "day": "/public/images/maps/050-day.png",
       "night": "/public/images/maps/050-night.png"
     },
-    "breed_power": 1070
+    "breeding": {
+      "rank": 1070,
+      "order": 95,
+      "child_eligble": true,
+      "male_probability": 10.0
+    }
   },
   {
     "id": 51,
@@ -5779,7 +6029,12 @@
       "day": "/public/images/maps/051-day.png",
       "night": "/public/images/maps/051-night.png"
     },
-    "breed_power": 330
+    "breeding": {
+      "rank": 330,
+      "order": 94,
+      "child_eligble": true,
+      "male_probability": 10.0
+    }
   },
   {
     "id": 52,
@@ -5886,7 +6141,12 @@
       "day": "/public/images/maps/052-day.png",
       "night": "/public/images/maps/052-night.png"
     },
-    "breed_power": 510
+    "breeding": {
+      "rank": 510,
+      "order": 131,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 53,
@@ -5998,7 +6258,12 @@
       "day": "/public/images/maps/053-day.png",
       "night": "/public/images/maps/053-night.png"
     },
-    "breed_power": 1300
+    "breeding": {
+      "rank": 1300,
+      "order": 114,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 54,
@@ -6110,7 +6375,12 @@
       "day": "/public/images/maps/054-day.png",
       "night": "/public/images/maps/054-night.png"
     },
-    "breed_power": 410
+    "breeding": {
+      "rank": 410,
+      "order": 115,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 55,
@@ -6222,7 +6492,12 @@
       "day": "/public/images/maps/055-day.png",
       "night": "/public/images/maps/055-night.png"
     },
-    "breed_power": 800
+    "breeding": {
+      "rank": 800,
+      "order": 123,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 56,
@@ -6334,7 +6609,12 @@
       "day": "/public/images/maps/056-day.png",
       "night": "/public/images/maps/056-night.png"
     },
-    "breed_power": 680
+    "breeding": {
+      "rank": 680,
+      "order": 19,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 57,
@@ -6441,7 +6721,12 @@
       "day": "/public/images/maps/057-day.png",
       "night": "/public/images/maps/057-night.png"
     },
-    "breed_power": 760
+    "breeding": {
+      "rank": 760,
+      "order": 104,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 58,
@@ -6553,7 +6838,12 @@
       "day": "/public/images/maps/058-day.png",
       "night": "/public/images/maps/058-night.png"
     },
-    "breed_power": 360
+    "breeding": {
+      "rank": 360,
+      "order": 35,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 59,
@@ -6665,7 +6955,12 @@
       "day": "/public/images/maps/059-day.png",
       "night": "/public/images/maps/059-night.png"
     },
-    "breed_power": 880
+    "breeding": {
+      "rank": 880,
+      "order": 76,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 60,
@@ -6772,7 +7067,12 @@
       "day": "/public/images/maps/060-day.png",
       "night": "/public/images/maps/060-night.png"
     },
-    "breed_power": 740
+    "breeding": {
+      "rank": 740,
+      "order": 100,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 61,
@@ -6878,7 +7178,12 @@
     "maps": {
       "night": "/public/images/maps/061-night.png"
     },
-    "breed_power": 830
+    "breeding": {
+      "rank": 830,
+      "order": 56,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 62,
@@ -6995,7 +7300,12 @@
       "day": "/public/images/maps/062-day.png",
       "night": "/public/images/maps/062-night.png"
     },
-    "breed_power": 1210
+    "breeding": {
+      "rank": 1210,
+      "order": 24,
+      "child_eligble": true,
+      "male_probability": 20.0
+    }
   },
   {
     "id": 63,
@@ -7109,7 +7419,12 @@
     "price": 1760,
     "size": "m",
     "maps": {},
-    "breed_power": 1110
+    "breeding": {
+      "rank": 1110,
+      "order": 22,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 64,
@@ -7221,7 +7536,12 @@
       "day": "/public/images/maps/064-day.png",
       "night": "/public/images/maps/064-night.png"
     },
-    "breed_power": 820
+    "breeding": {
+      "rank": 820,
+      "order": 63,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 65,
@@ -7328,7 +7648,12 @@
       "day": "/public/images/maps/065-day.png",
       "night": "/public/images/maps/065-night.png"
     },
-    "breed_power": 560
+    "breeding": {
+      "rank": 560,
+      "order": 42,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 66,
@@ -7439,7 +7764,12 @@
     "maps": {
       "night": "/public/images/maps/066-night.png"
     },
-    "breed_power": 1150
+    "breeding": {
+      "rank": 1150,
+      "order": 51,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 67,
@@ -7546,7 +7876,12 @@
       "day": "/public/images/maps/067-day.png",
       "night": "/public/images/maps/067-night.png"
     },
-    "breed_power": 850
+    "breeding": {
+      "rank": 850,
+      "order": 11,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 68,
@@ -7662,7 +7997,12 @@
     "maps": {
       "night": "/public/images/maps/068-night.png"
     },
-    "breed_power": 750
+    "breeding": {
+      "rank": 750,
+      "order": 96,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 69,
@@ -7783,7 +8123,12 @@
     "maps": {
       "night": "/public/images/maps/069-night.png"
     },
-    "breed_power": 940
+    "breeding": {
+      "rank": 940,
+      "order": 81,
+      "child_eligble": true,
+      "male_probability": 30.0
+    }
   },
   {
     "id": 70,
@@ -7905,7 +8250,12 @@
       "day": "/public/images/maps/070-day.png",
       "night": "/public/images/maps/070-night.png"
     },
-    "breed_power": 1405
+    "breeding": {
+      "rank": 1405,
+      "order": 137,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 71,
@@ -8017,7 +8367,12 @@
       "day": "/public/images/maps/071-day.png",
       "night": "/public/images/maps/071-night.png"
     },
-    "breed_power": 660
+    "breeding": {
+      "rank": 660,
+      "order": 60,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 72,
@@ -8144,7 +8499,12 @@
       "day": "/public/images/maps/072-day.png",
       "night": "/public/images/maps/072-night.png"
     },
-    "breed_power": 640
+    "breeding": {
+      "rank": 640,
+      "order": 127,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 73,
@@ -8261,7 +8621,12 @@
       "day": "/public/images/maps/073-day.png",
       "night": "/public/images/maps/073-night.png"
     },
-    "breed_power": 220
+    "breeding": {
+      "rank": 220,
+      "order": 118,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 74,
@@ -8373,7 +8738,12 @@
       "day": "/public/images/maps/074-day.png",
       "night": "/public/images/maps/074-night.png"
     },
-    "breed_power": 380
+    "breeding": {
+      "rank": 380,
+      "order": 126,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 75,
@@ -8489,7 +8859,12 @@
     "maps": {
       "night": "/public/images/maps/075-night.png"
     },
-    "breed_power": 700
+    "breeding": {
+      "rank": 700,
+      "order": 116,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 76,
@@ -8606,7 +8981,12 @@
       "day": "/public/images/maps/076-day.png",
       "night": "/public/images/maps/076-night.png"
     },
-    "breed_power": 1160
+    "breeding": {
+      "rank": 1160,
+      "order": 80,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 77,
@@ -8733,7 +9113,12 @@
       "day": "/public/images/maps/077-day.png",
       "night": "/public/images/maps/077-night.png"
     },
-    "breed_power": 990
+    "breeding": {
+      "rank": 990,
+      "order": 103,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 78,
@@ -8860,7 +9245,12 @@
       "day": "/public/images/maps/078-day.png",
       "night": "/public/images/maps/078-night.png"
     },
-    "breed_power": 1050
+    "breeding": {
+      "rank": 1050,
+      "order": 89,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 79,
@@ -8977,7 +9367,12 @@
       "day": "/public/images/maps/079-day.png",
       "night": "/public/images/maps/079-night.png"
     },
-    "breed_power": 450
+    "breeding": {
+      "rank": 450,
+      "order": 78,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 80,
@@ -9084,7 +9479,12 @@
       "day": "/public/images/maps/080-day.png",
       "night": "/public/images/maps/080-night.png"
     },
-    "breed_power": 540
+    "breeding": {
+      "rank": 540,
+      "order": 37,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 81,
@@ -9191,7 +9591,12 @@
       "day": "/public/images/maps/081-day.png",
       "night": "/public/images/maps/081-night.png"
     },
-    "breed_power": 1260
+    "breeding": {
+      "rank": 1260,
+      "order": 83,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 82,
@@ -9298,7 +9703,12 @@
       "day": "/public/images/maps/082-day.png",
       "night": "/public/images/maps/082-night.png"
     },
-    "breed_power": 500
+    "breeding": {
+      "rank": 500,
+      "order": 45,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 83,
@@ -9415,7 +9825,12 @@
       "day": "/public/images/maps/083-day.png",
       "night": "/public/images/maps/083-night.png"
     },
-    "breed_power": 130
+    "breeding": {
+      "rank": 130,
+      "order": 40,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 84,
@@ -9527,7 +9942,12 @@
       "day": "/public/images/maps/084-day.png",
       "night": "/public/images/maps/084-night.png"
     },
-    "breed_power": 710
+    "breeding": {
+      "rank": 710,
+      "order": 108,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 85,
@@ -9639,7 +10059,12 @@
       "day": "/public/images/maps/085-day.png",
       "night": "/public/images/maps/085-night.png"
     },
-    "breed_power": 280
+    "breeding": {
+      "rank": 280,
+      "order": 54,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 86,
@@ -9746,7 +10171,12 @@
       "day": "/public/images/maps/086-day.png",
       "night": "/public/images/maps/086-night.png"
     },
-    "breed_power": 860
+    "breeding": {
+      "rank": 860,
+      "order": 71,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 87,
@@ -9873,7 +10303,12 @@
       "day": "/public/images/maps/087-day.png",
       "night": "/public/images/maps/087-night.png"
     },
-    "breed_power": 780
+    "breeding": {
+      "rank": 780,
+      "order": 130,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 88,
@@ -9985,7 +10420,12 @@
       "day": "/public/images/maps/088-day.png",
       "night": "/public/images/maps/088-night.png"
     },
-    "breed_power": 320
+    "breeding": {
+      "rank": 320,
+      "order": 49,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 89,
@@ -10092,7 +10532,12 @@
       "day": "/public/images/maps/089-day.png",
       "night": "/public/images/maps/089-night.png"
     },
-    "breed_power": 470
+    "breeding": {
+      "rank": 470,
+      "order": 110,
+      "child_eligble": true,
+      "male_probability": 90.0
+    }
   },
   {
     "id": 90,
@@ -10209,7 +10654,12 @@
       "day": "/public/images/maps/090-day.png",
       "night": "/public/images/maps/090-night.png"
     },
-    "breed_power": 300
+    "breeding": {
+      "rank": 300,
+      "order": 68,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 91,
@@ -10331,7 +10781,12 @@
       "day": "/public/images/maps/091-day.png",
       "night": "/public/images/maps/091-night.png"
     },
-    "breed_power": 460
+    "breeding": {
+      "rank": 460,
+      "order": 87,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 92,
@@ -10453,7 +10908,12 @@
       "day": "/public/images/maps/092-day.png",
       "night": "/public/images/maps/092-night.png"
     },
-    "breed_power": 340
+    "breeding": {
+      "rank": 340,
+      "order": 119,
+      "child_eligble": true,
+      "male_probability": 85.0
+    }
   },
   {
     "id": 93,
@@ -10560,7 +11020,12 @@
       "day": "/public/images/maps/093-day.png",
       "night": "/public/images/maps/093-night.png"
     },
-    "breed_power": 980
+    "breeding": {
+      "rank": 980,
+      "order": 48,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 94,
@@ -10664,7 +11129,12 @@
     "price": 2100,
     "size": "m",
     "maps": {},
-    "breed_power": 1010
+    "breeding": {
+      "rank": 1010,
+      "order": 70,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 95,
@@ -10786,7 +11256,12 @@
       "day": "/public/images/maps/095-day.png",
       "night": "/public/images/maps/095-night.png"
     },
-    "breed_power": 350
+    "breeding": {
+      "rank": 350,
+      "order": 124,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 96,
@@ -10898,7 +11373,12 @@
       "day": "/public/images/maps/096-day.png",
       "night": "/public/images/maps/096-night.png"
     },
-    "breed_power": 10
+    "breeding": {
+      "rank": 10,
+      "order": 74,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 97,
@@ -11004,7 +11484,12 @@
     "maps": {
       "night": "/public/images/maps/097-night.png"
     },
-    "breed_power": 190
+    "breeding": {
+      "rank": 190,
+      "order": 125,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 98,
@@ -11116,7 +11601,12 @@
       "day": "/public/images/maps/098-day.png",
       "night": "/public/images/maps/098-night.png"
     },
-    "breed_power": 150
+    "breeding": {
+      "rank": 150,
+      "order": 102,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 99,
@@ -11228,7 +11718,12 @@
       "day": "/public/images/maps/099-day.png",
       "night": "/public/images/maps/099-night.png"
     },
-    "breed_power": 260
+    "breeding": {
+      "rank": 260,
+      "order": 133,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 100,
@@ -11342,7 +11837,12 @@
     "price": 4960,
     "size": "m",
     "maps": {},
-    "breed_power": 570
+    "breeding": {
+      "rank": 570,
+      "order": 1,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 101,
@@ -11449,7 +11949,12 @@
       "day": "/public/images/maps/101-day.png",
       "night": "/public/images/maps/101-night.png"
     },
-    "breed_power": 310
+    "breeding": {
+      "rank": 310,
+      "order": 28,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 102,
@@ -11556,7 +12061,12 @@
       "day": "/public/images/maps/102-day.png",
       "night": "/public/images/maps/102-night.png"
     },
-    "breed_power": 50
+    "breeding": {
+      "rank": 50,
+      "order": 33,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 103,
@@ -11678,7 +12188,12 @@
       "day": "/public/images/maps/103-day.png",
       "night": "/public/images/maps/103-night.png"
     },
-    "breed_power": 200
+    "breeding": {
+      "rank": 200,
+      "order": 13,
+      "child_eligble": false,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 104,
@@ -11804,7 +12319,12 @@
       "day": "/public/images/maps/104-day.png",
       "night": "/public/images/maps/104-night.png"
     },
-    "breed_power": 250
+    "breeding": {
+      "rank": 250,
+      "order": 92,
+      "child_eligble": false,
+      "male_probability": 30.0
+    }
   },
   {
     "id": 105,
@@ -11916,7 +12436,12 @@
       "day": "/public/images/maps/105-day.png",
       "night": "/public/images/maps/105-night.png"
     },
-    "breed_power": 370
+    "breeding": {
+      "rank": 370,
+      "order": 73,
+      "child_eligble": false,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 106,
@@ -12033,7 +12558,12 @@
       "day": "/public/images/maps/106-day.png",
       "night": "/public/images/maps/106-night.png"
     },
-    "breed_power": 140
+    "breeding": {
+      "rank": 140,
+      "order": 134,
+      "child_eligble": false,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 107,
@@ -12140,7 +12670,12 @@
       "day": "/public/images/maps/107-day.png",
       "night": "/public/images/maps/107-night.png"
     },
-    "breed_power": 60
+    "breeding": {
+      "rank": 60,
+      "order": 77,
+      "child_eligble": false,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 108,
@@ -12252,7 +12787,12 @@
       "day": "/public/images/maps/108-day.png",
       "night": "/public/images/maps/108-night.png"
     },
-    "breed_power": 80
+    "breeding": {
+      "rank": 80,
+      "order": 120,
+      "child_eligble": false,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 109,
@@ -12364,7 +12904,12 @@
       "day": "/public/images/maps/109-day.png",
       "night": "/public/images/maps/109-night.png"
     },
-    "breed_power": 70
+    "breeding": {
+      "rank": 70,
+      "order": 129,
+      "child_eligble": false,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 110,
@@ -12471,7 +13016,12 @@
       "day": "/public/images/maps/110-day.png",
       "night": "/public/images/maps/110-night.png"
     },
-    "breed_power": 120
+    "breeding": {
+      "rank": 120,
+      "order": 66,
+      "child_eligble": false,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 111,
@@ -12578,7 +13128,12 @@
       "day": "/public/images/maps/111-day.png",
       "night": "/public/images/maps/111-night.png"
     },
-    "breed_power": 90
+    "breeding": {
+      "rank": 90,
+      "order": 105,
+      "child_eligble": false,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 112,
@@ -12682,7 +13237,12 @@
     "price": 1070,
     "size": "xs",
     "maps": {},
-    "breed_power": 1360
+    "breeding": {
+      "rank": 1360,
+      "order": 18,
+      "child_eligble": false,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 113,
@@ -12794,7 +13354,12 @@
       "day": "/public/images/maps/024B-day.png",
       "night": "/public/images/maps/024B-night.png"
     },
-    "breed_power": 1440
+    "breeding": {
+      "rank": 1440,
+      "order": 5,
+      "child_eligble": false,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 114,
@@ -12910,7 +13475,12 @@
     "maps": {
       "day": "/public/images/maps/031B-day.png"
     },
-    "breed_power": 1100
+    "breeding": {
+      "rank": 1100,
+      "order": 26,
+      "child_eligble": false,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 115,
@@ -13031,7 +13601,12 @@
     "maps": {
       "night": "/public/images/maps/032B-night.png"
     },
-    "breed_power": 1422
+    "breeding": {
+      "rank": 1422,
+      "order": 32,
+      "child_eligble": false,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 116,
@@ -13153,7 +13728,12 @@
       "day": "/public/images/maps/033B-day.png",
       "night": "/public/images/maps/033B-night.png"
     },
-    "breed_power": 390
+    "breeding": {
+      "rank": 390,
+      "order": 98,
+      "child_eligble": false,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 117,
@@ -13260,7 +13840,12 @@
       "day": "/public/images/maps/037B-day.png",
       "night": "/public/images/maps/037B-night.png"
     },
-    "breed_power": 900
+    "breeding": {
+      "rank": 900,
+      "order": 10,
+      "child_eligble": false,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 118,
@@ -13377,7 +13962,12 @@
       "day": "/public/images/maps/040B-day.png",
       "night": "/public/images/maps/040B-night.png"
     },
-    "breed_power": 580
+    "breeding": {
+      "rank": 580,
+      "order": 3,
+      "child_eligble": false,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 119,
@@ -13499,7 +14089,12 @@
       "day": "/public/images/maps/045B-day.png",
       "night": "/public/images/maps/045B-night.png"
     },
-    "breed_power": 1140
+    "breeding": {
+      "rank": 1140,
+      "order": 58,
+      "child_eligble": false,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 120,
@@ -13626,7 +14221,12 @@
       "day": "/public/images/maps/048B-day.png",
       "night": "/public/images/maps/048B-night.png"
     },
-    "breed_power": 1000
+    "breeding": {
+      "rank": 1000,
+      "order": 53,
+      "child_eligble": false,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 121,
@@ -13737,7 +14337,12 @@
     "maps": {
       "night": "/public/images/maps/058B-night.png"
     },
-    "breed_power": 240
+    "breeding": {
+      "rank": 240,
+      "order": 36,
+      "child_eligble": false,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 122,
@@ -13849,7 +14454,12 @@
       "day": "/public/images/maps/064B-day.png",
       "night": "/public/images/maps/064B-night.png"
     },
-    "breed_power": 810
+    "breeding": {
+      "rank": 810,
+      "order": 64,
+      "child_eligble": false,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 123,
@@ -13956,7 +14566,12 @@
       "day": "/public/images/maps/065B-day.png",
       "night": "/public/images/maps/065B-night.png"
     },
-    "breed_power": 550
+    "breeding": {
+      "rank": 550,
+      "order": 43,
+      "child_eligble": false,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 124,
@@ -14067,7 +14682,12 @@
     "maps": {
       "night": "/public/images/maps/071B-night.png"
     },
-    "breed_power": 620
+    "breeding": {
+      "rank": 620,
+      "order": 61,
+      "child_eligble": false,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 125,
@@ -14176,7 +14796,12 @@
     "price": 5320,
     "size": "l",
     "maps": {},
-    "breed_power": 530
+    "breeding": {
+      "rank": 530,
+      "order": 38,
+      "child_eligble": false,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 126,
@@ -14283,7 +14908,12 @@
       "day": "/public/images/maps/081B-day.png",
       "night": "/public/images/maps/081B-night.png"
     },
-    "breed_power": 1270
+    "breeding": {
+      "rank": 1270,
+      "order": 84,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 127,
@@ -14394,7 +15024,12 @@
     "maps": {
       "night": "/public/images/maps/084B-night.png"
     },
-    "breed_power": 670
+    "breeding": {
+      "rank": 670,
+      "order": 109,
+      "child_eligble": false,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 128,
@@ -14503,7 +15138,12 @@
     "price": 10380,
     "size": "xl",
     "maps": {},
-    "breed_power": 270
+    "breeding": {
+      "rank": 270,
+      "order": 55,
+      "child_eligble": false,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 129,
@@ -14610,7 +15250,12 @@
       "day": "/public/images/maps/086B-day.png",
       "night": "/public/images/maps/086B-night.png"
     },
-    "breed_power": 840
+    "breeding": {
+      "rank": 840,
+      "order": 72,
+      "child_eligble": false,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 130,
@@ -14719,7 +15364,12 @@
     "price": 7380,
     "size": "l",
     "maps": {},
-    "breed_power": 230
+    "breeding": {
+      "rank": 230,
+      "order": 50,
+      "child_eligble": false,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 131,
@@ -14831,7 +15481,12 @@
       "day": "/public/images/maps/089B-day.png",
       "night": "/public/images/maps/089B-night.png"
     },
-    "breed_power": 440
+    "breeding": {
+      "rank": 440,
+      "order": 111,
+      "child_eligble": false,
+      "male_probability": 90.0
+    }
   },
   {
     "id": 132,
@@ -14948,7 +15603,12 @@
       "day": "/public/images/maps/090B-day.png",
       "night": "/public/images/maps/090B-night.png"
     },
-    "breed_power": 290
+    "breeding": {
+      "rank": 290,
+      "order": 69,
+      "child_eligble": false,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 133,
@@ -15070,7 +15730,12 @@
       "day": "/public/images/maps/091B-day.png",
       "night": "/public/images/maps/091B-night.png"
     },
-    "breed_power": 480
+    "breeding": {
+      "rank": 480,
+      "order": 88,
+      "child_eligble": true,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 134,
@@ -15177,7 +15842,12 @@
       "day": "/public/images/maps/101B-day.png",
       "night": "/public/images/maps/101B-night.png"
     },
-    "breed_power": 315
+    "breeding": {
+      "rank": 315,
+      "order": 29,
+      "child_eligble": false,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 135,
@@ -15281,7 +15951,12 @@
     "price": 10110,
     "size": "xl",
     "maps": {},
-    "breed_power": 30
+    "breeding": {
+      "rank": 30,
+      "order": 34,
+      "child_eligble": false,
+      "male_probability": 50.0
+    }
   },
   {
     "id": 136,
@@ -15402,7 +16077,12 @@
       "day": "/public/images/maps/104B-day.png",
       "night": "/public/images/maps/104B-night.png"
     },
-    "breed_power": 210
+    "breeding": {
+      "rank": 210,
+      "order": 93,
+      "child_eligble": false,
+      "male_probability": 30.0
+    }
   },
   {
     "id": 137,
@@ -15506,6 +16186,11 @@
     "price": 8560,
     "size": "l",
     "maps": {},
-    "breed_power": 100
+    "breeding": {
+      "rank": 100,
+      "order": 67,
+      "child_eligble": false,
+      "male_probability": 50.0
+    }
   }
 ]


### PR DESCRIPTION
The `breed.rank` can be used to calculate the children for two parents:

$$ \text{Child Rank} = \lfloor \frac{\text{ParentA Rank} + \text{ParentB Rank} + 1}{2} \rfloor $$

> "The game will then pick the Pal with the closest power to that average. [...] The 'tie breaker' (since 1015 is equal distance between 1010 and 1020) just comes down to the which Pal [has the lower `breed.order` number].
>
> ~ https://palworld.fandom.com/wiki/Breeding

For example, if you have _Penkin_ (Breed Power = `520`) and breed it with _Vanwyrm Cryst_ (Breed Power = `620`) you get a child with a Breed Power of `570`:

$$ \text{Child Rank} = \lfloor \frac{520 + 620 + 1}{2} \rfloor = 570 $$

The pal with the nearest distance to 570 is Anubis, so if you breed _Penkin_ with _Vanwym Cryst_ you'd get Anubis.
Some pals can only be bred if their parents are both of the type of the offspring. This is marked by the `breed.child_eligble` flag. 

<details>
<summary>There are a few special cases, however:</summary>

```py
    # Relaxaurus + Sparkit = Relaxaurus Lux
    "085+007": "085B",
    # Arsox + Broncherry = Kitsun
    "042+086": "061",
    # Direhowl + Gumoss = Maraith
    "026+013": "066",
    # Jormuntide + Shadowbeak = Helzephyr
    "101+107": "097",
    # Helzephyr + Shadowbeak = Cryolinx
    "097+107": "083",
    # Suzaku + Relaxaurus = Astegon
    "102+085": "098",
    # Penking + Bushi = Anubis
    "011+072": "100",
    # Incineram + Maraith = Incineram Noct
    "040+066": "040B",
    # Mau + Pengullet = Mau Cryst
    "024+010": "024B",
    # Vanwyrm + Foxcicle = Vanwyrm Cryst
    "071+057": "071B",
    # Eikthyrdeer + Hangyu = Eikthyrdeer Terra
    "037+032": "037B",
    # Elphidran + Surfent = Elphidran Aqua
    "080+065": "080B",
    # Pyrin + Katress = Pyrin Noct
    "058+075": "058B",
    # Mammorest + Wumpo = Mammorest Cryst
    "090+091": "090B",
    # Mossanda + Grizzbolt = Mossanda Lux
    "033+103": "033B",
    # Dinossom + Rayhound = Dinossom Lux
    "064+060": "064B",
    # Jolthog + Pengullet = Jolthog Cryst
    "012+010": "012B",
    # Frostallion + Helzephyr = Frostallion Noct
    "110+097": "110B",
    # Kingpaca + Reindrix = Kingpaca Cryst
    "089+059": "089B",
    # Lyleen + Menasting = Lyleen Noct
    "104+099": "104B",
    # Leezpunk + Flambelle = Leezpunk Ignis
    "045+070": "045B",
    # Blazehowl + Felbat = Blazehowl Noct
    "084+094": "084B",
    # Robinquill + Fuddler = Robinquill Terra
    "048+022": "048B",
    # Broncherry + Fuack = Broncherry Aqua
    "086+006": "086B",
    # Surfent + Dumud = Surfent Terra
    "065+043": "065B",
    # Gobfin + Rooby = Gobfin Ignis
    "031+009": "031B",
    # Suzaku + Jormuntide = Suzaku Aqua
    "102+101": "102B",
    # Reptyro + Foxcicle = Reptyro Cryst
    "088+057": "088B",
    # Hangyu + Swee = Hangyu Cryst
    "032+053": "032B",
    # Mossanda + Petallia = Lyleen
    "033+087": "104",
    # Vanwyrm + Anubis = Faleris
    "071+100": "105",
    # Mossanda + Rayhound = Grizzbolt
    "033+060": "103",
    # Grizzbolt + Relaxaurus = Orserk
    "103+085": "106",
    # Kitsun + Astegon = Shadowbeak
    "061+098": "107",
    # Bushi + Arsox = Blazehowl
    "072+042": "084",
```
</details>

The breeding power data was taken from [@dini.rfl's Google Docs Sheet](https://docs.google.com/spreadsheets/u/1/d/1YgPc11dgdBUC8jXNp01b7gI6jNHoBRQGwrY_V6lXMgQ/htmlview?usp=sharing)
