### PR TITLE
fix: types filter since new structure

### DIFF
--- a/src/common/interfaces/pal.interface.ts
+++ b/src/common/interfaces/pal.interface.ts
@@ -1,5 +1,5 @@
 import type { ISuitability } from ".";
-import type { TypesEnum } from "../enums";
+import type { ITypes } from "./types.interface";
 import type { IAura } from "./aura.interface";
 import type { IBreedMeta } from "./breed.interface";
 import type { ISkill } from "./skill.interface";
@@ -10,7 +10,7 @@ export interface IPal {
   key: string;
   name: string;
   description: string;
-  types: TypesEnum[];
+  types: ITypes[];
   suitabilities: string[];
   suitability: ISuitability[];
   drops: string[];

--- a/src/common/interfaces/types.interface.ts
+++ b/src/common/interfaces/types.interface.ts
@@ -1,0 +1,6 @@
+import { TypesEnum } from "@enums/types.enum";
+
+export interface ITypes {
+    name: TypesEnum;
+    image: string;
+}

--- a/src/services/elasticunr.service.ts
+++ b/src/services/elasticunr.service.ts
@@ -18,6 +18,7 @@ pals.forEach((pal) => {
   search.addDoc({
     ...pal,
     suitabilities: pal.suitability.map((suitability) => suitability.type),
+    types: pal.types.map((type) => type.name),
   });
 });
 


### PR DESCRIPTION
- After the latest merge, I noticed that the terms query wasn't returning as many results. For example, 'terms=fire' would previously return 4 results, but this change now returns 10 and provides more related results
- I believe it's now because 'types' is an array of objects instead of an array of strings
- This fixes that issue, but in elasticunr.service.ts, on line 21, 'types' gives a TypeScript error. However, it still works, and the filter functions much better
- I recommend checking out the branch and seeing if you can fix it before merging and testing the term query :) 

